### PR TITLE
 Created ProductOrder table

### DIFF
--- a/bangazon-app/bangazon/api/models.py
+++ b/bangazon-app/bangazon/api/models.py
@@ -190,6 +190,16 @@ class CustomerSupport(models.Model):
     resolution_description = models.CharField(max_length=100)
     date_ticket_resolved = models.CharField(max_length=50)
 
+class ProductOrder(models.Model):
 
+    """auth: Jordan Nelson
+    purpose: A table created for the purpose querying between the Product and Order tables
+    properties:
+    Product = Foreign Key to the table Id of the Product table
+    Order = Foreign Key to the table Id of the Order table
+    """
+
+    Product = models.ForeignKey(Customer)
+    Order = models.ForeignKey(Order)
 
             

--- a/bangazon-app/bangazon/api/models.py
+++ b/bangazon-app/bangazon/api/models.py
@@ -199,7 +199,7 @@ class ProductOrder(models.Model):
     Order = Foreign Key to the table Id of the Order table
     """
 
-    Product = models.ForeignKey(Customer)
-    Order = models.ForeignKey(Order)
+    product = models.ForeignKey(Customer)
+    order = models.ForeignKey(Order)
 
             

--- a/bangazon-app/bangazon/api/serializers.py
+++ b/bangazon-app/bangazon/api/serializers.py
@@ -180,16 +180,3 @@ class CustomerSupportSerializer(serializers.HyperlinkedModelSerializer):
         """
         model = CustomerSupport
         exclude = ()
-
-class ProductOrderSerializer(serializers.HyperlinkedModelSerializer):
-    class Meta:
-        """
-        author: Jordan Nelson
-        purpose: extends the parent serializer class with validators
-        properties: model = specifies the model to be serialized
-                    exclude = specifies fields to be included (here we exclude none)
-
-        docs: http://www.django-rest-framework.org/api-guide/serializers/#serializer-inheritance 
-        """
-        model = ProductOrder
-        exclude = ()            

--- a/bangazon-app/bangazon/api/serializers.py
+++ b/bangazon-app/bangazon/api/serializers.py
@@ -180,8 +180,16 @@ class CustomerSupportSerializer(serializers.HyperlinkedModelSerializer):
         """
         model = CustomerSupport
         exclude = ()
-        
 
-            
-            
-            
+class ProductOrderSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        """
+        author: Jordan Nelson
+        purpose: extends the parent serializer class with validators
+        properties: model = specifies the model to be serialized
+                    exclude = specifies fields to be included (here we exclude none)
+
+        docs: http://www.django-rest-framework.org/api-guide/serializers/#serializer-inheritance 
+        """
+        model = ProductOrder
+        exclude = ()            


### PR DESCRIPTION
# ProductOrder Table creation

## Status
Ready.

## Description
This pull request creates the ProductOrder table which has two foreign keys that link to the Product and Order tables by their Id.

With this pull request - the user will not be able to make a migration until issue #48 ( [https://github.com/illegal-llamas/Bangazon-LLC/issues/48](https://github.com/illegal-llamas/Bangazon-LLC/issues/48) ) is resolved. 

### Related Tickets 
***
List all related tickets that are addressed by this pull request

[https://github.com/illegal-llamas/Bangazon-LLC/issues/49](https://github.com/illegal-llamas/Bangazon-LLC/issues/49)

### Impacted Areas of the Application
***
This Pull Request modifies the following files:
```
    models.py
    serializers.py
```

### Deploy Notes
***
Keep in mind this will give an error for "no such table Order."

For example: 
```
    git pull 
    git fetch --all
    git checkout jn_newtables
    python manage.py makemigrations
    python manage.py migrate
    python manage.py runserver
```