### PR TITLE
created employee and and computer employee data to seed tables

### DIFF
--- a/bangazon-app/bangazon/api/fixtures/employee_computer_data.json
+++ b/bangazon-app/bangazon/api/fixtures/employee_computer_data.json
@@ -1,0 +1,82 @@
+[
+  {
+    "model": "api.ComputerEmployee",
+    "pk": 1,
+    "fields": {
+      "employee": 1,
+      "computer": 1
+    }
+  },
+  {
+    "model": "api.ComputerEmployee",
+    "pk": 2,
+    "fields": {
+      "employee": 2,
+      "computer": 2
+    }
+  },
+  {
+    "model": "api.ComputerEmployee",
+    "pk": 3,
+    "fields": {
+      "employee": 3,
+      "computer": 3
+    }
+  },
+  {
+    "model": "api.ComputerEmployee",
+    "pk": 4,
+    "fields": {
+      "employee": 4,
+      "computer": 4
+    }
+  },
+  {
+    "model": "api.ComputerEmployee",
+    "pk": 5,
+    "fields": {
+      "employee": 5,
+      "computer": 5
+    }
+  },
+  {
+    "model": "api.ComputerEmployee",
+    "pk": 6,
+    "fields": {
+      "employee": 6,
+      "computer": 6
+    }
+  },
+  {
+    "model": "api.ComputerEmployee",
+    "pk": 7,
+    "fields": {
+      "employee": 7,
+      "computer": 7
+    }
+  },
+  {
+    "model": "api.ComputerEmployee",
+    "pk": 8,
+    "fields": {
+      "employee": 8,
+      "computer": 8
+    }
+  },
+  {
+    "model": "api.ComputerEmployee",
+    "pk": 9,
+    "fields": {
+      "employee": 9,
+      "computer": 9
+    }
+  },
+  {
+    "model": "api.ComputerEmployee",
+    "pk": 10,
+    "fields": {
+      "employee": 10,
+      "computer": 10
+    }
+  }
+]

--- a/bangazon-app/bangazon/api/fixtures/employee_data.json
+++ b/bangazon-app/bangazon/api/fixtures/employee_data.json
@@ -1,0 +1,122 @@
+[
+  {
+    "model": "api.employee",
+    "pk": 1,
+    "fields": {
+      "department": 1,
+      "first_name": "Casey",
+      "last_name": "Dailey",
+      "title": "job doer",
+      "pay": 1000000000,
+      "supervisor": "False"
+    }
+  },
+  {
+    "model": "api.employee",
+    "pk": 2,
+    "fields": {
+      "department": 2,
+      "first_name": "Kayla",
+      "last_name": "Brewer",
+      "title": "job doer",
+      "pay": 1000000000,
+      "supervisor": "True"
+    }
+  },
+  {
+    "model": "api.employee",
+    "pk": 3,
+    "fields": {
+      "department": 3,
+      "first_name": "Jordan",
+      "last_name": "Nelson",
+      "title": "job doer",
+      "pay": 1000000000,
+      "supervisor": "False"
+    }
+  },
+  {
+    "model": "api.employee",
+    "pk": 4,
+    "fields": {
+      "department": 4,
+      "first_name": "Harper",
+      "last_name": "Frankstone",
+      "title": "job doer",
+      "pay": 1000000000,
+      "supervisor": "False"
+    }
+  },
+  {
+    "model": "api.employee",
+    "pk": 5,
+    "fields": {
+      "department": 5,
+      "first_name": "Dean",
+      "last_name": "Smith",
+      "title": "job doer",
+      "pay": 1000000000,
+      "supervisor": "False"
+    }
+  },
+  {
+    "model": "api.employee",
+    "pk": 6,
+    "fields": {
+      "department": 6,
+      "first_name": "Taylor",
+      "last_name": "Perkins",
+      "title": "job doer",
+      "pay": 1000000000,
+      "supervisor": "False"
+    }
+  },
+  {
+    "model": "api.employee",
+    "pk": 7,
+    "fields": {
+      "department": 7,
+      "first_name": "Dara",
+      "last_name": "Thomas",
+      "title": "job doer",
+      "pay": 1000000000,
+      "supervisor": "False"
+    }
+  },
+  {
+    "model": "api.employee",
+    "pk": 8,
+    "fields": {
+      "department": 8,
+      "first_name": "Miriam",
+      "last_name": "Rosenbaum",
+      "title": "job doer",
+      "pay": 1000000000,
+      "supervisor": "False"
+    }
+  },
+  {
+    "model": "api.employee",
+    "pk": 9,
+    "fields": {
+      "department": 9,
+      "first_name": "Will",
+      "last_name": "Simms",
+      "title": "job doer",
+      "pay": 1000000000,
+      "supervisor": "False"
+    }
+  },
+  {
+    "model": "api.employee",
+    "pk": 10,
+    "fields": {
+      "department": 10,
+      "first_name": "William",
+      "last_name": "Caldwell",
+      "title": "job doer",
+      "pay": 1000000000,
+      "supervisor": "False"
+    }
+  }
+]


### PR DESCRIPTION
# created employee and and computer employee data to seed tables

## Status

READY

## Description

*  I've created seed data to populate the employee table and the employee computer table

### Related Tickets 
***
data entry:

https://github.com/illegal-llamas/Bangazon-LLC/issues/59

### Impacted Areas of the Application
***

```
   created: bangazon/api/fixtures/employee_computer_data.json
   created: bangazon/api/fixtures/employee_data.json
```

### Deploy Notes
***
from bangazon/Bangazon-LLC/bangazon-app:

run the following commands:

```
    git fetch --all
    git checkout cjd-employee-data
    python manage.py makemigrations
    python manage.py migrate --run-syncdb
    python manage.py loaddata bangazon/api/fixtures/employee_data.json
   python manage.py loaddata bangazon/api/fixtures/employee_computer_data.json
    python manage.py runserver
```
navigate to:  http://127.0.0.1:8000/
click on  "computer": "http://127.0.0.1:8000/computer/"
and verify that employees are being assigned to computers

note: we should consider a refactor regarding this logic. it seems like computers should be assigned  to an employee.